### PR TITLE
Fix(tracker): Add max_distance to CentroidTracker

### DIFF
--- a/src/tracker.py
+++ b/src/tracker.py
@@ -1,11 +1,12 @@
 import numpy as np
 
 class CentroidTracker:
-    def __init__(self, max_disappeared=50):
+    def __init__(self, max_disappeared=50, max_distance=75):
         self.next_object_id = 0
         self.objects = {}
         self.disappeared = {}
         self.max_disappeared = max_disappeared
+        self.max_distance = max_distance
 
     def register(self, centroid):
         self.objects[self.next_object_id] = centroid
@@ -46,6 +47,9 @@ class CentroidTracker:
 
             for (row, col) in zip(rows, cols):
                 if row in used_rows or col in used_cols:
+                    continue
+
+                if D[row, col] > self.max_distance:
                     continue
 
                 object_id = object_ids[row]


### PR DESCRIPTION
The CentroidTracker was being called with a `max_distance` parameter, but the class did not support it, causing a TypeError.

This commit adds the `max_distance` parameter to the `CentroidTracker`'s `__init__` method and implements the logic in the `update` method to filter out potential matches that are farther than this distance. This resolves the error and implements the likely intended behavior.