### PR TITLE
Fix: Defer YOLO model loading to fix startup error

### DIFF
--- a/app.py
+++ b/app.py
@@ -168,9 +168,7 @@ if uploaded_file and process_button:
         processor = process_video(
             video_path=video_path,
             line_coords=line_coords,
-            detection_threshold=detection_threshold,
-            img_width=IMG_WIDTH,
-            img_height=IMG_HEIGHT
+            detection_threshold=detection_threshold
         )
 
         log_entries = []


### PR DESCRIPTION
This commit fixes a startup error on Streamlit Cloud where the application would crash because it tried to load the YOLO model files before they were downloaded.

The error `Failed to open NetParameter file: yolo_model/yolov3.cfg` occurred because the `cv2.dnn.readNet()` call was at the global scope in `src/video_processing.py`, which is executed at import time.

The fix involves:
- Moving the model loading logic (`cv2.dnn.readNet` and loading class names) from the global scope into the `process_video` function.
- Passing the loaded `net` and `CLASSES` objects as arguments to the `detect_bicycles` function.

This ensures that the model files are only loaded when processing begins, which is after the `setup_yolo_model` function in `app.py` has already run and downloaded the necessary files.