### PR TITLE
fix: Pin opencv-python-headless to a compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow
-opencv-python-headless
+opencv-python-headless==4.5.5.64
 streamlit
 scikit-learn
 pandas


### PR DESCRIPTION
The application was failing on Streamlit Cloud due to an error in the OpenCV library when loading the YOLOv3 model. This was caused by an incompatible version of opencv-python-headless being installed.

This commit pins the version to 4.5.5.64, which is a known stable version for this use case, resolving the deployment error.