### PR TITLE
Fix: Pin dependency versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-tensorflow
 opencv-python-headless==4.5.5.64
-streamlit
-scikit-learn
-pandas
-numpy
-jupyter
-matplotlib
-requests
+streamlit==1.30.0
+scikit-learn==1.0.2
+pandas==1.4.0
+numpy==1.22.4
+requests==2.28.0


### PR DESCRIPTION
The application was failing on Streamlit Cloud with a numpy ImportError. This was caused by unpinned dependencies in requirements.txt, which led to incompatible library versions being installed.

This commit addresses the issue by:
- Pinning all dependencies to known compatible versions to ensure a stable environment.
- Removing unused libraries (tensorflow, jupyter, matplotlib) to simplify the setup.