### PR TITLE
Fix ModuleNotFoundError for distutils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python-headless==4.5.5.64
 streamlit==1.12.0
-numpy==1.22.4
+numpy==1.26.4
 requests==2.28.0


### PR DESCRIPTION
The `distutils` module was removed in Python 3.12, causing a `ModuleNotFoundError`. This was triggered by a dependency on an older version of `numpy`.

This change updates the `numpy` dependency in `requirements.txt` to `==1.26.4` to ensure a compatible version is used that does not rely on `distutils` and to ensure reproducible builds.