### PR TITLE
fix: Upgrade OpenCV version to fix model loading error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python-headless==4.5.5.64
+opencv-python-headless==4.8.0.76
 streamlit==1.33.0
 numpy==1.26.4
 requests==2.28.0


### PR DESCRIPTION
Upgraded `opencv-python-headless` from `4.5.5.64` to `4.8.0.76`.

This change addresses an error `Transpose the weights (except for convolutional) is not implemented` that occurs when loading the YOLOv3 model with the older OpenCV version on Streamlit Cloud.