### PR TITLE
Fix torch version incompatibility for Streamlit Cloud

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ streamlit==1.33.0
 numpy==1.26.4
 requests==2.28.0
 altair<5
-torch==2.3.0
-torchvision==0.18.0
-ultralytics==8.2.2
+torch==2.5.0
+torchvision==0.19.0
+ultralytics==8.2.42


### PR DESCRIPTION
The application was failing to deploy on Streamlit Cloud due to an incompatible `torch` version specified in `requirements.txt`.

This commit updates the following packages to versions compatible with the Streamlit Cloud environment:
- `torch` from `2.3.0` to `2.5.0`
- `torchvision` from `0.18.0` to `0.19.0`
- `ultralytics` from `8.2.2` to `8.2.42`